### PR TITLE
Don't perform main thread checks on Android when asserts are disabled

### DIFF
--- a/utils-internal/src/androidMain/kotlin/com/arkivanov/mvikotlin/utils/internal/Logs.kt
+++ b/utils-internal/src/androidMain/kotlin/com/arkivanov/mvikotlin/utils/internal/Logs.kt
@@ -35,7 +35,7 @@ private fun isAndroidLoggerAvailable(): Boolean =
     try {
         Log.isLoggable("", Log.DEBUG)
         true
-    } catch (ignored: Exception) {
+    } catch (ignored: Throwable) {
         false
     }
 

--- a/utils-internal/src/androidMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
+++ b/utils-internal/src/androidMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
@@ -7,7 +7,7 @@ import android.os.Looper
 internal actual fun getMainThreadId(): MainThreadId? =
     try {
         MainThreadId(Looper.getMainLooper().thread.id)
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
         logE("Unable to determine Main thread id: ${e.message}")
         null
     }

--- a/utils-internal/src/commonMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
+++ b/utils-internal/src/commonMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
@@ -22,6 +22,10 @@ internal expect fun isMainThread(mainThreadId: MainThreadId): Boolean
 internal expect fun getCurrentThreadDescription(): String
 
 fun isMainThread(): Boolean {
+    if (!isAssertOnMainThreadEnabled) {
+        return true
+    }
+
     val mainThreadId =
         mainThreadIdRef.initAndGet {
             val id: MainThreadId? = getMainThreadId()


### PR DESCRIPTION
Fix: #91 