### PR TITLE
Add aggregation for DSL API

### DIFF
--- a/mvikotlin-extensions-coroutines/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/coroutines/CoroutineExecutionHandler.kt
+++ b/mvikotlin-extensions-coroutines/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/coroutines/CoroutineExecutionHandler.kt
@@ -1,0 +1,13 @@
+package com.arkivanov.mvikotlin.extensions.coroutines
+
+import com.arkivanov.mvikotlin.core.store.ExecutionHandler
+import com.arkivanov.mvikotlin.core.store.directExecutionHandler
+import com.arkivanov.mvikotlin.core.store.typedExecutionHandler
+import com.arkivanov.mvikotlin.core.utils.ExperimentalMviKotlinApi
+
+@OptIn(ExperimentalMviKotlinApi::class)
+inline fun <reified T : Any, Action : Any, State : Any, Message : Any, Label : Any> coroutineExecutionHandler(
+    noinline handler: CoroutineExecutorScope<State, Message, Action, Label>.(T) -> Unit
+): ExecutionHandler<T, CoroutineExecutorScope<State, Message, Action, Label>> {
+    return typedExecutionHandler(directExecutionHandler(handler))
+}

--- a/mvikotlin-extensions-coroutines/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/coroutines/CoroutineExecutionHandler.kt
+++ b/mvikotlin-extensions-coroutines/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/coroutines/CoroutineExecutionHandler.kt
@@ -4,10 +4,48 @@ import com.arkivanov.mvikotlin.core.store.ExecutionHandler
 import com.arkivanov.mvikotlin.core.store.directExecutionHandler
 import com.arkivanov.mvikotlin.core.store.typedExecutionHandler
 import com.arkivanov.mvikotlin.core.utils.ExperimentalMviKotlinApi
+import kotlinx.coroutines.Job
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalMviKotlinApi::class)
 inline fun <reified T : Any, Action : Any, State : Any, Message : Any, Label : Any> coroutineExecutionHandler(
     noinline handler: CoroutineExecutorScope<State, Message, Action, Label>.(T) -> Unit
 ): ExecutionHandler<T, CoroutineExecutorScope<State, Message, Action, Label>> {
     return typedExecutionHandler(directExecutionHandler(handler))
+}
+
+@OptIn(ExperimentalMviKotlinApi::class)
+inline fun <reified T : Any, Action : Any, State : Any, Message : Any, Label : Any> coroutineSkippingExecutionHandler(
+    noinline handler: CoroutineExecutorScope<State, Message, Action, Label>.(T) -> Unit
+): ExecutionHandler<T, CoroutineExecutorScope<State, Message, Action, Label>> {
+    return typedExecutionHandler(CoroutineSkippingExecutionHandler(handler))
+}
+
+@OptIn(ExperimentalMviKotlinApi::class)
+class CoroutineSkippingExecutionHandler<T : Any, State : Any, Message : Any, Action : Any, Label : Any> @PublishedApi internal constructor(
+    private val nestedHandler: CoroutineExecutorScope<State, Message, Action, Label>.(T) -> Unit,
+) : ExecutionHandler<T, CoroutineExecutorScope<State, Message, Action, Label>> {
+
+    private var jobHost: Job = Job()
+
+    override fun handle(scope: CoroutineExecutorScope<State, Message, Action, Label>, value: T): Boolean {
+        if (jobHost.children.any()) {
+            return false
+        }
+        val newScope = CoroutineSkippingExecutorScope(jobHost, scope)
+        nestedHandler.invoke(newScope, value)
+        return true
+    }
+
+}
+
+
+@OptIn(ExperimentalMviKotlinApi::class)
+private class CoroutineSkippingExecutorScope<State : Any, Message : Any, Action : Any, Label : Any>(
+    jobHost: Job,
+    private val parentScope: CoroutineExecutorScope<State, Message, Action, Label>,
+) : CoroutineExecutorScope<State, Message, Action, Label> by parentScope {
+
+    override val coroutineContext: CoroutineContext = parentScope.coroutineContext + jobHost
+
 }

--- a/mvikotlin-extensions-coroutines/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/coroutines/CoroutineExecutorDsl.kt
+++ b/mvikotlin-extensions-coroutines/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/coroutines/CoroutineExecutorDsl.kt
@@ -61,6 +61,18 @@ class CoroutineExecutorBuilder<Intent : Any, Action : Any, State : Any, Message 
     }
 
     /**
+     * Same as [onIntent], but skip intents if previous still is in process
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : Intent> onIntentSkipping(
+        noinline handler: CoroutineExecutorScope<State, Message, Action, Label>.(intent: T) -> Unit,
+    ) {
+        onIntent(
+            executionHandler = coroutineSkippingExecutionHandler(handler) as ExecutionHandler<Intent, CoroutineExecutorScope<State, Message, Action, Label>>
+        )
+    }
+
+    /**
      * Registers the provided [Action] ``[handler] for the given [Action] type [T].
      * The type is checked using *`is`* operator, so it is possible to use base or `sealed` interfaces or classes.
      */
@@ -70,6 +82,18 @@ class CoroutineExecutorBuilder<Intent : Any, Action : Any, State : Any, Message 
     ) {
         onAction(
             executionHandler = coroutineExecutionHandler(handler) as ExecutionHandler<Action, CoroutineExecutorScope<State, Message, Action, Label>>
+        )
+    }
+
+    /**
+     * Same as [onAction], but skip intents if previous still is in process
+     */
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : Action> onActionSkipping(
+        noinline handler: CoroutineExecutorScope<State, Message, Action, Label>.(action: T) -> Unit,
+    ) {
+        onAction(
+            executionHandler = coroutineSkippingExecutionHandler(handler) as ExecutionHandler<Action, CoroutineExecutorScope<State, Message, Action, Label>>
         )
     }
 }

--- a/mvikotlin-extensions-reaktive/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/reaktive/ReactiveExecutionHandler.kt
+++ b/mvikotlin-extensions-reaktive/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/reaktive/ReactiveExecutionHandler.kt
@@ -1,0 +1,13 @@
+package com.arkivanov.mvikotlin.extensions.reaktive
+
+import com.arkivanov.mvikotlin.core.store.ExecutionHandler
+import com.arkivanov.mvikotlin.core.store.directExecutionHandler
+import com.arkivanov.mvikotlin.core.store.typedExecutionHandler
+import com.arkivanov.mvikotlin.core.utils.ExperimentalMviKotlinApi
+
+@OptIn(ExperimentalMviKotlinApi::class)
+inline fun <reified T : Any, Action : Any, State : Any, Message : Any, Label : Any> reactiveExecutionHandler(
+    noinline handler: ReaktiveExecutorScope<State, Message, Action, Label>.(T) -> Unit
+): ExecutionHandler<T, ReaktiveExecutorScope<State, Message, Action, Label>> {
+    return typedExecutionHandler(directExecutionHandler(handler))
+}

--- a/mvikotlin-extensions-reaktive/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/reaktive/ReaktiveExecutorDsl.kt
+++ b/mvikotlin-extensions-reaktive/src/commonMain/kotlin/com/arkivanov/mvikotlin/extensions/reaktive/ReaktiveExecutorDsl.kt
@@ -1,10 +1,10 @@
 package com.arkivanov.mvikotlin.extensions.reaktive
 
+import com.arkivanov.mvikotlin.core.store.DslExecutorImpl
+import com.arkivanov.mvikotlin.core.store.ExecutionHandler
 import com.arkivanov.mvikotlin.core.store.Executor
+import com.arkivanov.mvikotlin.core.store.ExecutorBuilder
 import com.arkivanov.mvikotlin.core.utils.ExperimentalMviKotlinApi
-import com.arkivanov.mvikotlin.core.utils.internal.atomic
-import com.arkivanov.mvikotlin.core.utils.internal.initialize
-import com.arkivanov.mvikotlin.core.utils.internal.requireValue
 import com.badoo.reaktive.disposable.scope.DisposableScope
 
 /**
@@ -14,7 +14,7 @@ import com.badoo.reaktive.disposable.scope.DisposableScope
  */
 @ExperimentalMviKotlinApi
 fun <Intent : Any, Action : Any, State : Any, Message : Any, Label : Any> reaktiveExecutorFactory(
-    block: ExecutorBuilder<Intent, Action, State, Message, Label>.() -> Unit,
+    block: ReactiveExecutorBuilder<Intent, Action, State, Message, Label>.() -> Unit,
 ): () -> Executor<Intent, Action, State, Message, Label> =
     {
         executor(block)
@@ -22,109 +22,57 @@ fun <Intent : Any, Action : Any, State : Any, Message : Any, Label : Any> reakti
 
 @ExperimentalMviKotlinApi
 private fun <Intent : Any, Action : Any, State : Any, Message : Any, Label : Any> executor(
-    block: ExecutorBuilder<Intent, Action, State, Message, Label>.() -> Unit,
+    block: ReactiveExecutorBuilder<Intent, Action, State, Message, Label>.() -> Unit,
 ): Executor<Intent, Action, State, Message, Label> {
-    val builder = ExecutorBuilder<Intent, Action, State, Message, Label>()
+    val builder = ReactiveExecutorBuilder<Intent, Action, State, Message, Label>()
     block(builder)
 
-    return ExecutorImpl(
-        intentHandlers = builder.intentHandlers,
-        actionHandlers = builder.actionHandlers,
+    return ReactiveExecutorImpl(
+        builder = builder,
     )
 }
 
 @ExperimentalMviKotlinApi
 @ReaktiveExecutorDslMaker
-class ExecutorBuilder<Intent : Any, Action : Any, State : Any, Message : Any, Label : Any> internal constructor() {
-
-    @PublishedApi
-    internal val intentHandlers = ArrayList<ReaktiveExecutorScope<State, Message, Action, Label>.(Intent) -> Boolean>()
-
-    @PublishedApi
-    internal val actionHandlers = ArrayList<ReaktiveExecutorScope<State, Message, Action, Label>.(Action) -> Boolean>()
+class ReactiveExecutorBuilder<Intent : Any, Action : Any, State : Any, Message : Any, Label : Any> internal constructor() :
+    ExecutorBuilder<ReaktiveExecutorScope<State, Message, Action, Label>, Intent, Action, State, Message, Label>() {
 
     /**
      * Registers the provided [Intent] ``[handler] for the given [Intent] type [T].
      * The type is checked using *`is`* operator, so it is possible to use base or `sealed` interfaces or classes.
      */
+    @Suppress("UNCHECKED_CAST")
     inline fun <reified T : Intent> onIntent(
         noinline handler: ReaktiveExecutorScope<State, Message, Action, Label>.(intent: T) -> Unit,
     ) {
-        intentHandlers +=
-            { intent ->
-                if (intent is T) {
-                    handler(intent)
-                    true
-                } else {
-                    false
-                }
-            }
+        onIntent(reactiveExecutionHandler(handler) as ExecutionHandler<Intent, ReaktiveExecutorScope<State, Message, Action, Label>>)
     }
 
     /**
      * Registers the provided [Action] ``[handler] for the given [Action] type [T].
      * The type is checked using *`is`* operator, so it is possible to use base or `sealed` interfaces or classes.
      */
+    @Suppress("UNCHECKED_CAST")
     inline fun <reified T : Action> onAction(
         noinline handler: ReaktiveExecutorScope<State, Message, Action, Label>.(action: T) -> Unit,
     ) {
-        actionHandlers +=
-            { action ->
-                if (action is T) {
-                    handler(action)
-                    true
-                } else {
-                    false
-                }
-            }
+        onAction(reactiveExecutionHandler(handler) as ExecutionHandler<Action, ReaktiveExecutorScope<State, Message, Action, Label>>)
     }
 }
 
 @ExperimentalMviKotlinApi
-private class ExecutorImpl<in Intent : Any, Action : Any, State : Any, Message : Any, Label : Any>(
-    private val intentHandlers: List<ReaktiveExecutorScope<State, Message, Action, Label>.(Intent) -> Boolean>,
-    private val actionHandlers: List<ReaktiveExecutorScope<State, Message, Action, Label>.(Action) -> Boolean>,
+private class ReactiveExecutorImpl<in Intent : Any, Action : Any, State : Any, Message : Any, Label : Any>(
     private val scope: DisposableScope = DisposableScope(),
-) : Executor<Intent, Action, State, Message, Label>, ReaktiveExecutorScope<State, Message, Action, Label>, DisposableScope by scope {
+    builder: ExecutorBuilder<ReaktiveExecutorScope<State, Message, Action, Label>, Intent, Action, State, Message, Label>,
+) : DslExecutorImpl<ReaktiveExecutorScope<State, Message, Action, Label>, Intent, Action, State, Message, Label>(builder),
+    ReaktiveExecutorScope<State, Message, Action, Label>, DisposableScope by scope {
 
-    private val callbacks = atomic<Executor.Callbacks<State, Message, Action, Label>>()
-
-    override fun init(callbacks: Executor.Callbacks<State, Message, Action, Label>) {
-        this.callbacks.initialize(callbacks)
-    }
-
-    override fun state(): State =
-        callbacks.requireValue().state
-
-    override fun executeAction(action: Action) {
-        for (handler in actionHandlers) {
-            if (handler(this, action)) {
-                break
-            }
-        }
-    }
-
-    override fun executeIntent(intent: Intent) {
-        for (handler in intentHandlers) {
-            if (handler(this, intent)) {
-                break
-            }
-        }
+    override fun getScope(): ReaktiveExecutorScope<State, Message, Action, Label> {
+        return this
     }
 
     override fun dispose() {
         scope.dispose()
     }
 
-    override fun dispatch(message: Message) {
-        callbacks.requireValue().onMessage(message)
-    }
-
-    override fun forward(action: Action) {
-        callbacks.requireValue().onAction(action)
-    }
-
-    override fun publish(label: Label) {
-        callbacks.requireValue().onLabel(label)
-    }
 }

--- a/mvikotlin/src/commonMain/kotlin/com/arkivanov/mvikotlin/core/store/ExecutionHandler.kt
+++ b/mvikotlin/src/commonMain/kotlin/com/arkivanov/mvikotlin/core/store/ExecutionHandler.kt
@@ -1,0 +1,53 @@
+package com.arkivanov.mvikotlin.core.store
+
+import com.arkivanov.mvikotlin.core.utils.ExperimentalMviKotlinApi
+import kotlin.reflect.KClass
+
+interface ExecutionHandler<in T : Any, in Scope : Any> {
+
+    fun handle(scope: Scope, value: T): Boolean
+
+}
+
+
+inline fun <reified T : Any, Scope : Any> typedExecutionHandler(
+    nestedHandler: ExecutionHandler<T, Scope>,
+): ExecutionHandler<T, Scope> {
+    return TypeCheckingExecutionHandler(T::class, nestedHandler)
+}
+
+class TypeCheckingExecutionHandler<T : Any, Scope : Any>(
+    private val type: KClass<T>,
+    private val nestedHandler: ExecutionHandler<T, Scope>,
+) : ExecutionHandler<Any, Scope> {
+
+    override fun handle(scope: Scope, value: Any): Boolean {
+        return if (type.isInstance(value)) {
+            @Suppress("UNCHECKED_CAST")
+            nestedHandler.handle(scope, value as T)
+            return true
+        } else {
+            false
+        }
+    }
+
+}
+
+inline fun <reified T : Any, Scope : Any> directExecutionHandler(
+    noinline handler: Scope.(T) -> Unit
+): ExecutionHandler<T, Scope> {
+    return typedExecutionHandler(DirectExecutionHandler(handler))
+}
+
+
+class DirectExecutionHandler<T : Any, Scope : Any>(
+    private val nestedHandler: Scope.(T) -> Unit,
+) : ExecutionHandler<T, Scope> {
+
+    override fun handle(scope: Scope, value: T): Boolean {
+        nestedHandler.invoke(scope, value)
+        return true
+    }
+
+}
+

--- a/mvikotlin/src/commonMain/kotlin/com/arkivanov/mvikotlin/core/store/ExecutorBuilder.kt
+++ b/mvikotlin/src/commonMain/kotlin/com/arkivanov/mvikotlin/core/store/ExecutorBuilder.kt
@@ -1,0 +1,24 @@
+package com.arkivanov.mvikotlin.core.store
+
+import com.arkivanov.mvikotlin.core.utils.internal.InternalMviKotlinApi
+
+abstract class ExecutorBuilder<Scope : Any, Intent : Any, Action : Any, State : Any, Message : Any, Label : Any> {
+
+    internal val intentExecutionHandlers = ArrayList<ExecutionHandler<Intent, Scope>>()
+    internal val actionExecutionHandlers = ArrayList<ExecutionHandler<Action, Scope>>()
+
+
+    fun onIntent(
+        executionHandler: ExecutionHandler<Intent, Scope>
+    ) {
+        intentExecutionHandlers += executionHandler
+    }
+
+    fun onAction(
+        executionHandler: ExecutionHandler<Action, Scope>
+    ) {
+        actionExecutionHandlers += executionHandler
+    }
+
+
+}

--- a/mvikotlin/src/commonMain/kotlin/com/arkivanov/mvikotlin/core/store/ExecutorImpl.kt
+++ b/mvikotlin/src/commonMain/kotlin/com/arkivanov/mvikotlin/core/store/ExecutorImpl.kt
@@ -1,0 +1,57 @@
+package com.arkivanov.mvikotlin.core.store
+
+import com.arkivanov.mvikotlin.core.utils.ExperimentalMviKotlinApi
+import com.arkivanov.mvikotlin.core.utils.internal.InternalMviKotlinApi
+import com.arkivanov.mvikotlin.core.utils.internal.atomic
+import com.arkivanov.mvikotlin.core.utils.internal.initialize
+import com.arkivanov.mvikotlin.core.utils.internal.requireValue
+
+@InternalMviKotlinApi
+@ExperimentalMviKotlinApi
+abstract class DslExecutorImpl<Scope : Any, in Intent : Any, Action : Any, State : Any, Message : Any, Label : Any>(
+    builder: ExecutorBuilder<Scope, Intent, Action, State, Message, Label>,
+) : Executor<Intent, Action, State, Message, Label> {
+
+    private val intentHandlers = builder.intentExecutionHandlers
+    private val actionHandlers = builder.actionExecutionHandlers
+
+    private val callbacks = atomic<Executor.Callbacks<State, Message, Action, Label>>()
+
+    abstract fun getScope(): Scope
+
+    fun state(): State =
+        callbacks.requireValue().state
+
+    override fun init(callbacks: Executor.Callbacks<State, Message, Action, Label>) {
+        this.callbacks.initialize(callbacks)
+    }
+
+    override fun executeAction(action: Action) {
+        for (handler in actionHandlers) {
+            if (handler.handle(getScope(), action)) {
+                break
+            }
+        }
+    }
+
+    override fun executeIntent(intent: Intent) {
+        for (handler in intentHandlers) {
+            if (handler.handle(getScope(), intent)) {
+                break
+            }
+        }
+    }
+
+    fun dispatch(message: Message) {
+        callbacks.requireValue().onMessage(message)
+    }
+
+    fun forward(action: Action) {
+        callbacks.requireValue().onAction(action)
+    }
+
+    fun publish(label: Label) {
+        callbacks.requireValue().onLabel(label)
+    }
+
+}


### PR DESCRIPTION
To extend behaviour of store executor dsl api, you should to use something like
```kotlin
onIntentSkipping<AccountProfileSettingStore.Intent, _, _, _, _, _> {

}
```
and extension fun somewhere with implement necessary behaviour. 
With aggregation with ExecutionHandler you can add your own implementation for intent/action execution like filter by type TypeCheckExecutionHander, just call intent DirectExecutionHandler and aggregate one above another. 
For example, I add useful ExecutionHandler such as CoroutineSkippingExecutionHandler which skip intents while previous is in execution.
This aggregation extract to common mvikotlin module with ExecutorBuilder and abstract DslExecutorImpl, which implements common logic of process ExecutionHandlers.

For users, they will be able to create custom ExecutionHandlers and use it as 
```kotlin
onIntent(customExecutionHandler<Intent> {
/* some logic with Coroutine/ReactiveExecutorScope */
})
```
with usage of typedExecutionHander under the hood and own ExecutionHandler.

Other abilities with ExecutionHandlers as simple and extendable api are execute with debounce, execute after cancel previous intents, intents queue, which is able to become part of mvikotlin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced coroutine and reactive execution handling in MVI architecture, enhancing support for coroutine and reactive programming patterns.
	- Added new classes and functions for managing coroutine and reactive execution within MVI components.
	- Implemented new testing capabilities to verify coroutine execution scenarios.
- **Refactor**
	- Updated and renamed classes to align with coroutine and reactive execution paradigms.
	- Improved method signatures and refactored handler registration methods for better clarity and functionality.
- **Documentation**
	- Enhanced documentation to clearly describe the purpose and usage of new execution handling features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->